### PR TITLE
Change one-line conditions

### DIFF
--- a/parts/0000-library/Assets/Vendor/FPCSharpUnity/Editor/unity_serialization/UnityOptionOdin.cs
+++ b/parts/0000-library/Assets/Vendor/FPCSharpUnity/Editor/unity_serialization/UnityOptionOdin.cs
@@ -22,8 +22,7 @@ namespace FPCSharpUnity.unity.Editor.unity_serialization {
       var isSet = property.Children[isSomeName];
       var value = property.getChildSmart(valueName);
 
-      var oneLine = value.Children.Count == 0 ||
-                    value.Children.Count == 1 && value.Children[0].Children.Count == 0;
+      var oneLine = value.Children.Count == 0;
 
       SirenixEditorGUI.BeginHorizontalPropertyLayout(label);
       EditorGUI.BeginChangeCheck();


### PR DESCRIPTION
There is an issue with the structs that have only one field, and we want to use them in `UnityOption`. The input for the field will be hidden, only label is shown. 
![image](https://user-images.githubusercontent.com/107105173/172583524-fa70df90-a52a-4d5c-99af-13e5bbd5b780.png)
After the fix:
![image](https://user-images.githubusercontent.com/107105173/172583715-5dc09ffc-780c-42df-a12e-3160b9b2d005.png)
